### PR TITLE
LCAM 577 Disable Remote Debugging

### DIFF
--- a/crime-evidence/Dockerfile
+++ b/crime-evidence/Dockerfile
@@ -4,6 +4,5 @@ WORKDIR /opt/laa-crime-evidence/
 COPY ./build/libs/crime-evidence.jar /opt/laa-crime-evidence/app.jar
 RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
 USER 1001
-EXPOSE 8189 8199 8091
-ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8091
-ENTRYPOINT ["java","-jar","app.jar"]
+EXPOSE 8189 8199
+CMD java -jar app.jar

--- a/crime-evidence/docker-compose.yml
+++ b/crime-evidence/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     ports:
       - "8189:8189"
       - "8199:8199"
-      - "8091:8091"
 
     depends_on:
       - postgres


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881)

Improve security by disabling remote debugging in the application and closed associated ports.

**NOTE**: I was able to check the application built and tests passed but wasn't able to get the application running locally due to other defects present which are going to be tackled in another ticket. However confident that none of the changes here are causing the existing defects present.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
