### PR TITLE
LCAM 580 Evidence Service Fails to Initialise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 *.java-version
 .env
 gradle.properties
+pgdata/

--- a/crime-evidence/docker-compose.yml
+++ b/crime-evidence/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ~/apps/postgres:/var/lib/postgresql/data
+      - ./pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s

--- a/crime-evidence/src/main/resources/application.yaml
+++ b/crime-evidence/src/main/resources/application.yaml
@@ -43,11 +43,9 @@ spring:
     enabled: true
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
-    show-sql: true
-    generate-ddl: true
-    hibernate:
-      ddl-auto: validate
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: false
+    generate-ddl: false
     properties:
       hibernate.temp.use_jdbc_metadata_defaults: false
 

--- a/crime-evidence/src/main/resources/db.changelog/changeset/04-spring-security-oauth2-table-update.sql
+++ b/crime-evidence/src/main/resources/db.changelog/changeset/04-spring-security-oauth2-table-update.sql
@@ -2,5 +2,5 @@
 --changeset matthewh:04-spring-security-oauth2-table-update
 
 ALTER TABLE oauth2_authorization
-    ADD authorized_scopes varchar(1000) DEFAULT NULL AFTER authorization_grant_type;
+    ADD COLUMN authorized_scopes varchar(1000) DEFAULT NULL;
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-580)

Evidence service was failing to initialise due to issues around using the same persistent volume as CCP when running locally. Changed config so this application will generate and use its own persistent volume stored in the root of the application. Also fixed some more general issues config and sql syntax which were causing issues on startup.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
