### PR TITLE
LCAM-985: Upgraded crime commons version and enabled micrometer tracing

### DIFF
--- a/crime-evidence/build.gradle
+++ b/crime-evidence/build.gradle
@@ -20,7 +20,7 @@ def versions = [
         mockwebserverVersion   : "4.10.0",
         pitest                 : "1.4.10",
         commonsLang3Version    : "3.10",
-        crimeCommonsVersion    : "2.2.0",
+        crimeCommonsVersion    : "2.7.0",
         wiremockVersion        : "2.35.0"
 
 ]

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/CrimeEvidenceApplication.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/CrimeEvidenceApplication.java
@@ -2,12 +2,13 @@ package uk.gov.justice.laa.crime.evidence;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @Slf4j
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 @ConfigurationPropertiesScan
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 public class CrimeEvidenceApplication {

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/ErrorDTO.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/ErrorDTO.java
@@ -6,6 +6,7 @@ import lombok.Value;
 @Value
 @Builder
 public class ErrorDTO {
+    private String traceId;
     private String code;
     private String message;
 }

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/exception/CrimeEvidenceExceptionHandler.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/exception/CrimeEvidenceExceptionHandler.java
@@ -1,32 +1,36 @@
 package uk.gov.justice.laa.crime.evidence.exception;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import uk.gov.justice.laa.crime.commons.exception.APIClientException;
+import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.evidence.dto.ErrorDTO;
 
-
-@RestControllerAdvice
 @Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
 public class CrimeEvidenceExceptionHandler {
 
-    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, String errorMessage) {
+    private final TraceIdHandler traceIdHandler;
+
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, String errorMessage, String traceId) {
         return new ResponseEntity<>(ErrorDTO.builder().code(status.toString()).message(errorMessage).build(), status);
     }
 
     @ExceptionHandler(APIClientException.class)
     public ResponseEntity<ErrorDTO> handleApiClientError(APIClientException ex) {
         log.error("APIClientException: ", ex);
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(CrimeEvidenceDataException.class)
     public ResponseEntity<ErrorDTO> handleCrimeEvidenceDataException(CrimeEvidenceDataException ex) {
         log.error("CrimeEvidenceDataException: ", ex);
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
 }

--- a/crime-evidence/src/main/resources/application.yaml
+++ b/crime-evidence/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+  tracing:
+    propagation:
+      type: w3c,b3
 
 springdoc:
   packagesToScan: uk.gov.justice.laa.crime.evidence

--- a/crime-evidence/src/main/resources/logback.xml
+++ b/crime-evidence/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} traceId: %X{traceId:-} spanId: %X{spanId:-} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/config/CrimeEvidenceTestConfiguration.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/config/CrimeEvidenceTestConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.evidence.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -9,6 +10,7 @@ import java.time.Instant;
 import java.util.Map;
 
 @TestConfiguration
+@ComponentScan(basePackages = {"uk.gov.justice.laa.crime.commons.tracing"})
 public class CrimeEvidenceTestConfiguration {
 
     static final String SUB = "sub";


### PR DESCRIPTION
## What

[LCAM-985](https://dsdmoj.atlassian.net/browse/LCAM-985)

Describe what you did and why.

- Upgraded to crime commons v2.7.0 to include micrometer tracing
- Updated Exception handler to include traceId in error response
- Updated application.yaml to enable micrometer tracing for Evidence
- Updated logback.xml to include traceId and spanId
- Updated controller and Integration tests

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LCAM-985]: https://dsdmoj.atlassian.net/browse/LCAM-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ