### PR TITLE
[LCAM-1402]|Migrate create default income evidence stored procedure

### DIFF
--- a/crime-evidence/build.gradle
+++ b/crime-evidence/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "jacoco"
-    id "org.springframework.boot" version "3.1.5"
+    id "org.springframework.boot" version "3.3.5"
     id 'io.spring.dependency-management' version '1.1.4'
     id "org.sonarqube" version "4.4.1.3373"
     id "info.solidsoft.pitest" version "1.15.0"
@@ -17,7 +17,7 @@ def versions = [
         pitest                : "1.16.0",
         crimeCommonsClasses   : "3.29.3",
         commonsModSchemas     : "1.17.0",
-        commonsRestClient     : "3.4.0",
+        commonsRestClient     : "3.18.0",
         wmStubRunnerVersion   : "4.1.2",
         springDocWebMVCVersion: "2.5.0",
         postgresqlVersion     : "42.7.2"

--- a/crime-evidence/build.gradle
+++ b/crime-evidence/build.gradle
@@ -16,7 +16,7 @@ jacoco {
 def versions = [
         pitest                : "1.16.0",
         crimeCommonsClasses   : "3.29.3",
-        commonsModSchemas     : "1.16.0",
+        commonsModSchemas     : "1.17.0",
         commonsRestClient     : "3.4.0",
         wmStubRunnerVersion   : "4.1.2",
         springDocWebMVCVersion: "2.5.0",

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilder.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilder.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.laa.crime.evidence.builder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
+import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateEvidenceDTOBuilder {
+
+    public static CreateEvidenceDTO build(final ApiCreateIncomeEvidenceRequest request) {
+        return CreateEvidenceDTO.builder()
+            .magCourtOutcome(request.getMagCourtOutcome())
+            .applicantDetails(request.getApplicantDetails())
+            .applicantPensionAmount(request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount().doubleValue() : 0)
+            .partnerDetails(request.getPartnerDetails())
+            .partnerPensionAmount(request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount().doubleValue() : 0)
+            .build();
+    }
+}

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilder.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilder.java
@@ -4,9 +4,9 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
-import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
+
+import java.math.BigDecimal;
 
 @Component
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,9 +16,9 @@ public class CreateEvidenceDTOBuilder {
         return CreateEvidenceDTO.builder()
             .magCourtOutcome(request.getMagCourtOutcome())
             .applicantDetails(request.getApplicantDetails())
-            .applicantPensionAmount(request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount().doubleValue() : 0)
+            .applicantPensionAmount(request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount() : BigDecimal.ZERO)
             .partnerDetails(request.getPartnerDetails())
-            .partnerPensionAmount(request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount().doubleValue() : 0)
+            .partnerPensionAmount(request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount() : BigDecimal.ZERO)
             .build();
     }
 }

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/UpdateEvidenceDTOBuilder.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/builder/UpdateEvidenceDTOBuilder.java
@@ -13,7 +13,6 @@ public class UpdateEvidenceDTOBuilder {
 
     public static UpdateEvidenceDTO build(final ApiUpdateIncomeEvidenceRequest request) {
         return UpdateEvidenceDTO.builder()
-            .financialAssessmentId(request.getFinancialAssessmentId())
             .magCourtOutcome(request.getMagCourtOutcome())
             .applicantDetails(request.getApplicantEvidenceItems() != null ? request.getApplicantEvidenceItems().getApplicantDetails() : null)
             .applicantPensionAmount(request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount() : BigDecimal.ZERO)

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceController.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceController.java
@@ -13,9 +13,12 @@ import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceReq
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.evidence.builder.CreateEvidenceDTOBuilder;
 import uk.gov.justice.laa.crime.evidence.builder.UpdateEvidenceDTOBuilder;
+import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.service.EvidenceService;
+import uk.gov.justice.laa.crime.evidence.service.IncomeEvidenceService;
 
 @Slf4j
 @RestController
@@ -25,10 +28,12 @@ import uk.gov.justice.laa.crime.evidence.service.EvidenceService;
 public class IncomeEvidenceController implements IncomeEvidenceApi {
 
     private final EvidenceService evidenceService;
+    private final IncomeEvidenceService incomeEvidenceService;
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiCreateIncomeEvidenceResponse> createEvidence(ApiCreateIncomeEvidenceRequest request) {
-        return ResponseEntity.ok().build();
+        CreateEvidenceDTO createEvidenceDTO = CreateEvidenceDTOBuilder.build(request);
+        return ResponseEntity.ok(incomeEvidenceService.createEvidence(createEvidenceDTO));
     }
 
     @PutMapping(produces = MediaType.APPLICATION_JSON_VALUE)

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceController.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceController.java
@@ -17,7 +17,6 @@ import uk.gov.justice.laa.crime.evidence.builder.CreateEvidenceDTOBuilder;
 import uk.gov.justice.laa.crime.evidence.builder.UpdateEvidenceDTOBuilder;
 import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
-import uk.gov.justice.laa.crime.evidence.service.EvidenceService;
 import uk.gov.justice.laa.crime.evidence.service.IncomeEvidenceService;
 
 @Slf4j
@@ -27,7 +26,6 @@ import uk.gov.justice.laa.crime.evidence.service.IncomeEvidenceService;
 @Tag(name = "Income Evidence", description = "Rest API for Income Evidence")
 public class IncomeEvidenceController implements IncomeEvidenceApi {
 
-    private final EvidenceService evidenceService;
     private final IncomeEvidenceService incomeEvidenceService;
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -40,6 +38,6 @@ public class IncomeEvidenceController implements IncomeEvidenceApi {
     public ResponseEntity<ApiUpdateIncomeEvidenceResponse> updateEvidence(ApiUpdateIncomeEvidenceRequest request) {
         UpdateEvidenceDTO updateEvidenceDTO = UpdateEvidenceDTOBuilder.build(request);
 
-        return ResponseEntity.ok(evidenceService.updateEvidence(updateEvidenceDTO));
+        return ResponseEntity.ok(incomeEvidenceService.updateEvidence(updateEvidenceDTO));
     }
 }

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/CreateEvidenceDTO.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/CreateEvidenceDTO.java
@@ -5,12 +5,14 @@ import lombok.Data;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
 import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 public class CreateEvidenceDTO {
     private MagCourtOutcome magCourtOutcome;
     private ApiApplicantDetails applicantDetails;
     private ApiApplicantDetails partnerDetails;
-    private double applicantPensionAmount;
-    private double partnerPensionAmount;
+    private BigDecimal applicantPensionAmount;
+    private BigDecimal partnerPensionAmount;
 }

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/CreateEvidenceDTO.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/CreateEvidenceDTO.java
@@ -1,0 +1,16 @@
+package uk.gov.justice.laa.crime.evidence.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
+
+@Data
+@Builder
+public class CreateEvidenceDTO {
+    private MagCourtOutcome magCourtOutcome;
+    private ApiApplicantDetails applicantDetails;
+    private ApiApplicantDetails partnerDetails;
+    private double applicantPensionAmount;
+    private double partnerPensionAmount;
+}

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/UpdateEvidenceDTO.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/dto/UpdateEvidenceDTO.java
@@ -13,7 +13,6 @@ import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 @Data
 @Builder
 public class UpdateEvidenceDTO {
-    private int financialAssessmentId;
     private List<ApiIncomeEvidence> applicantIncomeEvidenceItems;
     private List<ApiIncomeEvidence> partnerIncomeEvidenceItems;
     private MagCourtOutcome magCourtOutcome;

--- a/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/service/EvidenceService.java
+++ b/crime-evidence/src/main/java/uk/gov/justice/laa/crime/evidence/service/EvidenceService.java
@@ -5,28 +5,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCalculateEvidenceFeeResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiEvidenceFee;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidenceItems;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;
 import uk.gov.justice.laa.crime.evidence.builder.EvidenceFeeRulesDTOBuilder;
 import uk.gov.justice.laa.crime.evidence.common.Constants;
 import uk.gov.justice.laa.crime.evidence.dto.CrimeEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.dto.EvidenceFeeRulesDTO;
-import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
-import uk.gov.justice.laa.crime.evidence.staticdata.enums.ApplicantType;
 import uk.gov.justice.laa.crime.evidence.staticdata.enums.EvidenceFeeRules;
-import uk.gov.justice.laa.crime.util.DateUtil;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EvidenceService {
-    private final IncomeEvidenceService incomeEvidenceService;
-    private final IncomeEvidenceValidationService incomeEvidenceValidationService;
     private final MaatCourtDataService maatCourtDataService;
 
     public ApiCalculateEvidenceFeeResponse calculateEvidenceFee(CrimeEvidenceDTO crimeEvidenceDTO) {
@@ -75,86 +64,10 @@ public class EvidenceService {
         return apiProcessRepOrderResponse;
     }
 
-    public ApiUpdateIncomeEvidenceResponse updateEvidence(UpdateEvidenceDTO updateEvidenceDTO) {
-        List<ApiIncomeEvidence> applicantEvidenceItems = updateEvidenceDTO.getApplicantIncomeEvidenceItems();
-        List<ApiIncomeEvidence> partnerEvidenceItems = updateEvidenceDTO.getPartnerIncomeEvidenceItems();
-
-        if (applicantEvidenceItems.isEmpty() && partnerEvidenceItems.isEmpty()) {
-            throw new IllegalArgumentException("No income evidence items provided");
-        }
-
-        incomeEvidenceValidationService.checkEvidenceReceivedDate(
-            DateUtil.parseLocalDate(updateEvidenceDTO.getEvidenceReceivedDate()),
-            updateEvidenceDTO.getApplicationReceivedDate());
-
-        incomeEvidenceValidationService.checkExtraEvidenceDescriptions(applicantEvidenceItems);
-        incomeEvidenceValidationService.checkExtraEvidenceDescriptions(partnerEvidenceItems);
-
-        incomeEvidenceValidationService.checkEvidenceDueDates(
-            DateUtil.parseLocalDate(updateEvidenceDTO.getEvidenceDueDate()),
-            DateUtil.parseLocalDate(updateEvidenceDTO.getPreviousEvidenceDueDate()),
-            updateEvidenceDTO.isEvidencePending());
-
-        boolean applicantEvidenceItemsReceived = true;
-        boolean partnerEvidenceItemsReceived = true;
-
-        if (!applicantEvidenceItems.isEmpty()) {
-            applicantEvidenceItemsReceived = incomeEvidenceService.checkEvidenceReceived(
-                applicantEvidenceItems,
-                updateEvidenceDTO.getMagCourtOutcome(),
-                updateEvidenceDTO.getApplicantDetails().getEmploymentStatus(),
-                updateEvidenceDTO.getPartnerDetails() != null
-                    ? updateEvidenceDTO.getPartnerDetails().getEmploymentStatus() : null,
-                updateEvidenceDTO.getApplicantPensionAmount(),
-                ApplicantType.APPLICANT);
-        }
-
-        if (!partnerEvidenceItems.isEmpty()) {
-            partnerEvidenceItemsReceived = incomeEvidenceService.checkEvidenceReceived(
-                partnerEvidenceItems,
-                updateEvidenceDTO.getMagCourtOutcome(),
-                updateEvidenceDTO.getApplicantDetails().getEmploymentStatus(),
-                updateEvidenceDTO.getPartnerDetails().getEmploymentStatus(),
-                updateEvidenceDTO.getPartnerPensionAmount(),
-                ApplicantType.PARTNER);
-        }
-
-        boolean allEvidenceItemsReceived = applicantEvidenceItemsReceived && partnerEvidenceItemsReceived;
-
-        updateEvidenceReceivedDate(updateEvidenceDTO, allEvidenceItemsReceived);
-        updateEvidenceDueDate(updateEvidenceDTO);
-
-        ApiUpdateIncomeEvidenceResponse response = new ApiUpdateIncomeEvidenceResponse()
-            .withApplicantEvidenceItems(new ApiIncomeEvidenceItems(updateEvidenceDTO.getApplicantDetails(), applicantEvidenceItems))
-            .withDueDate(DateUtil.parseLocalDate(updateEvidenceDTO.getEvidenceDueDate()))
-            .withAllEvidenceReceivedDate(DateUtil.parseLocalDate(updateEvidenceDTO.getEvidenceReceivedDate()));
-
-        if (!partnerEvidenceItems.isEmpty()) {
-            response.setPartnerEvidenceItems(new ApiIncomeEvidenceItems(updateEvidenceDTO.getPartnerDetails(), partnerEvidenceItems));
-        }
-
-        return response;
-    }
-
     protected boolean isCalcRequired(CrimeEvidenceDTO crimeEvidenceDTO) {
         return (crimeEvidenceDTO.getMagCourtOutcome().equalsIgnoreCase(Constants.SENT_FOR_TRIAL)
                 || crimeEvidenceDTO.getMagCourtOutcome().equalsIgnoreCase(Constants.COMMITTED_FOR_TRIAL)) &&
                 (crimeEvidenceDTO.getEvidenceFee() == null || crimeEvidenceDTO.getEvidenceFee().getFeeLevel() == null);
     }
 
-    private void updateEvidenceDueDate(UpdateEvidenceDTO updateEvidenceDTO) {
-        LocalDateTime previousEvidenceDueDate = updateEvidenceDTO.getPreviousEvidenceDueDate();
-
-        if (updateEvidenceDTO.getEvidenceDueDate() == null && previousEvidenceDueDate != null) {
-            updateEvidenceDTO.setEvidenceDueDate(previousEvidenceDueDate);
-        }
-    }
-
-    private void updateEvidenceReceivedDate(UpdateEvidenceDTO updateEvidenceDTO, boolean evidenceReceived) {
-        if (evidenceReceived && updateEvidenceDTO.getEvidenceReceivedDate() == null) {
-            updateEvidenceDTO.setEvidenceReceivedDate(LocalDateTime.now());
-        } else if (!evidenceReceived && updateEvidenceDTO.getEvidenceReceivedDate() != null) {
-            updateEvidenceDTO.setEvidenceReceivedDate(null);
-        }
-    }
 }

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilderTest.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilderTest.java
@@ -36,8 +36,8 @@ class CreateEvidenceDTOBuilderTest {
     @ParameterizedTest
     @MethodSource("createIncomeEvidenceRequest")
     void givenCreateIncomeEvidenceRequest_whenBuildIsInvoked_thenCorrectCreateEvidenceDTOFieldsArePopulated(ApiCreateIncomeEvidenceRequest request) {
-        double applicantPension = request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount().doubleValue() : 0;
-        double partnerPension = request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount().doubleValue() : 0;
+        BigDecimal applicantPension = request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount() : BigDecimal.ZERO;
+        BigDecimal partnerPension = request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount() : BigDecimal.ZERO;
         CreateEvidenceDTO createEvidenceDTO = CreateEvidenceDTOBuilder.build(request);
         softly.assertThat(createEvidenceDTO.getMagCourtOutcome()).isEqualTo(request.getMagCourtOutcome());
         softly.assertThat(createEvidenceDTO.getPartnerDetails()).isEqualTo(request.getPartnerDetails());

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilderTest.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/builder/CreateEvidenceDTOBuilderTest.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.laa.crime.evidence.builder;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.evidence.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+@ExtendWith(SoftAssertionsExtension.class)
+class CreateEvidenceDTOBuilderTest {
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+
+    public static Stream<Arguments> createIncomeEvidenceRequest() {
+        return Stream.of(
+            Arguments.of(new ApiCreateIncomeEvidenceRequest()
+                .withApplicantDetails(TestModelDataBuilder.getApiApplicantDetails())),
+            Arguments.of(new ApiCreateIncomeEvidenceRequest()
+                .withApplicantDetails(TestModelDataBuilder.getApiApplicantDetails())
+                .withApplicantPensionAmount(BigDecimal.ONE)),
+            Arguments.of(new ApiCreateIncomeEvidenceRequest()
+                .withApplicantDetails(TestModelDataBuilder.getApiApplicantDetails())
+                .withPartnerDetails(TestModelDataBuilder.getApiPartnerDetails())
+                .withPartnerPensionAmount(BigDecimal.TEN))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createIncomeEvidenceRequest")
+    void givenCreateIncomeEvidenceRequest_whenBuildIsInvoked_thenCorrectCreateEvidenceDTOFieldsArePopulated(ApiCreateIncomeEvidenceRequest request) {
+        double applicantPension = request.getApplicantPensionAmount() != null ? request.getApplicantPensionAmount().doubleValue() : 0;
+        double partnerPension = request.getPartnerPensionAmount() != null ? request.getPartnerPensionAmount().doubleValue() : 0;
+        CreateEvidenceDTO createEvidenceDTO = CreateEvidenceDTOBuilder.build(request);
+        softly.assertThat(createEvidenceDTO.getMagCourtOutcome()).isEqualTo(request.getMagCourtOutcome());
+        softly.assertThat(createEvidenceDTO.getPartnerDetails()).isEqualTo(request.getPartnerDetails());
+        softly.assertThat(createEvidenceDTO.getApplicantDetails()).isEqualTo(request.getApplicantDetails());
+
+        softly.assertThat(createEvidenceDTO.getPartnerPensionAmount()).isEqualTo(partnerPension);
+        softly.assertThat(createEvidenceDTO.getApplicantPensionAmount()).isEqualTo(applicantPension);
+        softly.assertAll();
+    }
+}

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceControllerTest.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceControllerTest.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.laa.crime.evidence.controller;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,18 +12,16 @@ import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceReq
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.evidence.data.builder.TestModelDataBuilder;
-import uk.gov.justice.laa.crime.evidence.service.EvidenceService;
 import uk.gov.justice.laa.crime.evidence.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.util.RequestBuilderUtils;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(IncomeEvidenceController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class IncomeEvidenceControllerTest {
 
     private static final String ENDPOINT_URL = "/api/internal/v1/evidence";
-
-    @MockBean
-    private EvidenceService evidenceService;
 
     @Autowired
     private MockMvc mvc;

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceControllerTest.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/controller/IncomeEvidenceControllerTest.java
@@ -15,6 +15,7 @@ import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceReq
 import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.evidence.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.evidence.service.EvidenceService;
+import uk.gov.justice.laa.crime.evidence.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.util.RequestBuilderUtils;
 
 @WebMvcTest(IncomeEvidenceController.class)
@@ -34,6 +35,9 @@ class IncomeEvidenceControllerTest {
 
     @MockBean
     private TraceIdHandler traceIdHandler;
+
+    @MockBean
+    private IncomeEvidenceService incomeEvidenceService;
 
     @Test
     void givenMissingRequestBody_whenCreateEvidenceIsInvoked_thenBadRequestResponseIsReturned() throws Exception {

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/data/builder/TestModelDataBuilder.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/data/builder/TestModelDataBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.evidence.data.builder;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.evidence.*;
@@ -9,6 +10,7 @@ import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
 import uk.gov.justice.laa.crime.evidence.common.Constants;
 import uk.gov.justice.laa.crime.evidence.dto.CapitalEvidenceDTO;
+import uk.gov.justice.laa.crime.evidence.dto.CreateEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.dto.CrimeEvidenceDTO;
 import uk.gov.justice.laa.crime.evidence.dto.EvidenceFeeDTO;
 
@@ -187,6 +189,8 @@ public class TestModelDataBuilder {
             .evidenceReceivedDate(DateUtil.convertDateToDateTime(evidenceReceivedDate))
             .previousEvidenceDueDate(DateUtil.convertDateToDateTime(previousEvidenceDueDate))
             .partnerIncomeEvidenceItems(Collections.emptyList())
+            .partnerPensionAmount(BigDecimal.ZERO)
+            .applicantPensionAmount(BigDecimal.ZERO)
             .build();
     }
 
@@ -197,5 +201,15 @@ public class TestModelDataBuilder {
                 .withMandatory(true)
                 .withEvidenceType(incomeEvidenceType)
                 .withDateReceived(EVIDENCE_RECEIVED_DATE);
+    }
+
+    public static CreateEvidenceDTO getCreateEvidenceRequest() {
+        return CreateEvidenceDTO.builder()
+                .magCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
+                .applicantDetails(getApiApplicantDetails())
+                .partnerDetails(getApiPartnerDetails())
+                .applicantPensionAmount(BigDecimal.TEN)
+                .partnerPensionAmount(BigDecimal.ZERO)
+                .build();
     }
 }

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/data/builder/TestModelDataBuilder.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/data/builder/TestModelDataBuilder.java
@@ -32,7 +32,6 @@ public class TestModelDataBuilder {
 
     public static final String EMST_CODE = "SELF";
     public static final int APPLICANT_ID = 5708;
-    public static final int FINANCIAL_ASSESSMENT_ID = 4509;
     public static final int PARTNER_ID = 6336;
     public static final String TEST_USER_NAME = "mock-u";
     public static final LocalDateTime DUE_DATE = LocalDateTime.of(2024, 8, 15, 0, 0, 0);
@@ -103,7 +102,6 @@ public class TestModelDataBuilder {
         return new ApiCreateIncomeEvidenceRequest()
                 .withMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
                 .withApplicantDetails(getApiApplicantDetails())
-                .withFinancialAssessmentId(FINANCIAL_ASSESSMENT_ID)
                 .withPartnerDetails(getApiPartnerDetails())
                 .withMetadata(getApiIncomeEvidenceMetadata());
     }
@@ -127,7 +125,6 @@ public class TestModelDataBuilder {
         return new ApiUpdateIncomeEvidenceRequest()
                 .withEvidenceDueDate(DUE_DATE)
                 .withMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
-                .withFinancialAssessmentId(FINANCIAL_ASSESSMENT_ID)
                 .withMetadata(getApiIncomeEvidenceMetadata());
     }
 
@@ -164,7 +161,6 @@ public class TestModelDataBuilder {
             .magCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
             .applicantIncomeEvidenceItems(Collections.emptyList())
             .partnerIncomeEvidenceItems(Collections.emptyList())
-            .financialAssessmentId(FINANCIAL_ASSESSMENT_ID)
             .build();
     }
 
@@ -191,7 +187,6 @@ public class TestModelDataBuilder {
             .evidenceReceivedDate(DateUtil.convertDateToDateTime(evidenceReceivedDate))
             .previousEvidenceDueDate(DateUtil.convertDateToDateTime(previousEvidenceDueDate))
             .partnerIncomeEvidenceItems(Collections.emptyList())
-            .financialAssessmentId(FINANCIAL_ASSESSMENT_ID)
             .build();
     }
 

--- a/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/service/EvidenceServiceTest.java
+++ b/crime-evidence/src/test/java/uk/gov/justice/laa/crime/evidence/service/EvidenceServiceTest.java
@@ -1,38 +1,21 @@
 package uk.gov.justice.laa.crime.evidence.service;
 
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidenceItems;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
-import uk.gov.justice.laa.crime.enums.EmploymentStatus;
-import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCalculateEvidenceFeeResponse;
+import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;
 import uk.gov.justice.laa.crime.evidence.common.Constants;
 import uk.gov.justice.laa.crime.evidence.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.evidence.dto.CrimeEvidenceDTO;
-import uk.gov.justice.laa.crime.common.model.evidence.ApiCalculateEvidenceFeeResponse;
-import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;
-import uk.gov.justice.laa.crime.evidence.dto.UpdateEvidenceDTO;
-import uk.gov.justice.laa.crime.evidence.staticdata.enums.ApplicantType;
-import uk.gov.justice.laa.crime.util.DateUtil;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,12 +27,6 @@ class EvidenceServiceTest {
 
     @InjectMocks
     private EvidenceService evidenceService;
-
-    @Mock
-    private IncomeEvidenceService incomeEvidenceService;
-
-    @Mock
-    private IncomeEvidenceValidationService incomeEvidenceValidationService;
 
     @InjectSoftAssertions
     private SoftAssertions softly;
@@ -137,166 +114,5 @@ class EvidenceServiceTest {
         CrimeEvidenceDTO requestDTO = TestModelDataBuilder.getCrimeEvidenceDTO();
         requestDTO.getEvidenceFee().setFeeLevel(EvidenceFeeLevel.LEVEL1.getDescription());
         assertThat(evidenceService.isCalcRequired(requestDTO)).isFalse();
-    }
-
-    @Test
-    void givenNoEvidenceItems_whenUpdateEvidenceIsInvoked_thenExceptionIsThrown() {
-        UpdateEvidenceDTO updateEvidenceDTO = TestModelDataBuilder.getUpdateEvidenceRequest();
-
-        assertThatThrownBy(() -> evidenceService.updateEvidence(updateEvidenceDTO))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No income evidence items provided");
-    }
-
-    @Test
-    void givenValidationErrorOnEvidenceReceivedDate_whenUpdateEvidenceIsInvoked_thenExceptionIsThrown() {
-        LocalDate applicationReceivedDate = LocalDate.of(2024, 8, 30);
-        LocalDate evidenceItemReceivedDate = LocalDate.of(2024, 8, 29);
-        LocalDate existingEvidenceDueDate = LocalDate.of(2024, 9, 7);
-
-        List<ApiIncomeEvidence> applicantEvidenceItems = List.of(
-            new ApiIncomeEvidence(1, evidenceItemReceivedDate, IncomeEvidenceType.ACCOUNTS, false, "Company accounts")
-        );
-
-        UpdateEvidenceDTO updateEvidenceDTO =  TestModelDataBuilder.getUpdateEvidenceRequest(
-            applicationReceivedDate,
-            null,
-            applicantEvidenceItems,
-            false,
-            null,
-            evidenceItemReceivedDate,
-            existingEvidenceDueDate);
-
-        doThrow(IllegalArgumentException.class).when(incomeEvidenceValidationService).checkEvidenceReceivedDate(
-            DateUtil.parseLocalDate(updateEvidenceDTO.getEvidenceReceivedDate()), updateEvidenceDTO.getApplicationReceivedDate());
-
-        assertThatThrownBy(() -> evidenceService.updateEvidence(updateEvidenceDTO))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void givenValidationErrorOnEvidenceDueDate_whenUpdateEvidenceIsInvoked_thenExceptionIsThrown() {
-        LocalDate applicationReceivedDate = LocalDate.of(2024, 8, 30);
-        LocalDate evidenceItemReceivedDate = LocalDate.of(2024, 8, 31);
-        LocalDate existingEvidenceDueDate = LocalDate.of(2024, 9, 7);
-
-        List<ApiIncomeEvidence> applicantEvidenceItems = List.of(
-            new ApiIncomeEvidence(1, evidenceItemReceivedDate, IncomeEvidenceType.ACCOUNTS, false, "Company accounts")
-        );
-
-        UpdateEvidenceDTO updateEvidenceDTO = TestModelDataBuilder.getUpdateEvidenceRequest(
-            applicationReceivedDate,
-            null,
-            applicantEvidenceItems,
-            true,
-            null,
-            evidenceItemReceivedDate,
-            existingEvidenceDueDate);
-
-        doThrow(IllegalArgumentException.class).when(incomeEvidenceValidationService).checkEvidenceDueDates(
-            null,
-            existingEvidenceDueDate,
-            true);
-
-        assertThatThrownBy(() -> evidenceService.updateEvidence(updateEvidenceDTO))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void givenEvidenceHasNotBeenReceivedAndIncomeEvidenceHasReceivedDate_whenUpdateEvidenceIsInvoked_thenIncomeEvidenceReceivedDateIsRemoved() {
-        LocalDate applicationReceivedDate = LocalDate.of(2024, 8, 30);
-        LocalDate evidenceItemReceivedDate = LocalDate.of(2024, 9, 1);
-        LocalDate evidenceDueDate = LocalDate.of(2024, 9, 30);
-        LocalDate evidenceReceivedDate = LocalDate.of(2024, 9, 1);
-        LocalDate existingEvidenceDueDate = LocalDate.of(2024, 9, 7);
-
-        List<ApiIncomeEvidence> applicantEvidenceItems = List.of(
-            new ApiIncomeEvidence(1, evidenceItemReceivedDate, IncomeEvidenceType.ACCOUNTS, false, "Company accounts")
-        );
-
-        ApiApplicantDetails applicantDetails = buildApplicantDetails(1, EmploymentStatus.EMPLOY);
-
-        UpdateEvidenceDTO updateEvidenceDTO = TestModelDataBuilder.getUpdateEvidenceRequest(
-            applicationReceivedDate,
-            applicantDetails,
-            applicantEvidenceItems,
-            false,
-            evidenceDueDate,
-            evidenceReceivedDate,
-            existingEvidenceDueDate);
-
-        when(incomeEvidenceService.checkEvidenceReceived(
-            eq(updateEvidenceDTO.getApplicantIncomeEvidenceItems()),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(ApplicantType.APPLICANT)))
-            .thenReturn(false);
-
-        ApiUpdateIncomeEvidenceResponse expectedResponse = new ApiUpdateIncomeEvidenceResponse()
-            .withApplicantEvidenceItems(new ApiIncomeEvidenceItems(applicantDetails, applicantEvidenceItems))
-            .withDueDate(evidenceDueDate)
-            .withAllEvidenceReceivedDate(null);
-
-        ApiUpdateIncomeEvidenceResponse actualResponse = evidenceService.updateEvidence(updateEvidenceDTO);
-
-        Assertions.assertNull(updateEvidenceDTO.getEvidenceReceivedDate());
-        Assertions.assertEquals(expectedResponse, actualResponse);
-    }
-
-    @Test
-    void givenOnlyPartnerEvidenceIsProvided_whenUpdateEvidenceIsInvoked_thenIncomeEvidenceIsUpdated() {
-        LocalDate applicationReceivedDate = LocalDate.of(2024, 8, 30);
-        LocalDate evidenceItemReceivedDate = LocalDate.of(2024, 9, 1);
-        LocalDate evidenceDueDate = LocalDate.of(2024, 9, 30);
-        LocalDate evidenceReceivedDate = LocalDate.of(2024, 9, 1);
-        LocalDate existingEvidenceDueDate = LocalDate.of(2024, 9, 7);
-
-        List<ApiIncomeEvidence> partnerEvidenceItems = List.of(
-            new ApiIncomeEvidence(1, evidenceItemReceivedDate, IncomeEvidenceType.ACCOUNTS, false, "Company accounts")
-        );
-
-        ApiApplicantDetails applicantDetails = buildApplicantDetails(1, EmploymentStatus.EMPLOY);
-        ApiApplicantDetails partnerDetails = buildApplicantDetails(2, EmploymentStatus.EMPLOYED_CASH);
-
-        UpdateEvidenceDTO updateEvidenceDTO = TestModelDataBuilder.getUpdateEvidenceRequest(
-            applicationReceivedDate,
-            applicantDetails,
-            null,
-            false,
-            evidenceDueDate,
-            evidenceReceivedDate,
-            existingEvidenceDueDate);
-        updateEvidenceDTO.setPartnerDetails(partnerDetails);
-        updateEvidenceDTO.setPartnerIncomeEvidenceItems(partnerEvidenceItems);
-
-        when(incomeEvidenceService.checkEvidenceReceived(
-            eq(updateEvidenceDTO.getPartnerIncomeEvidenceItems()),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(ApplicantType.PARTNER)))
-            .thenReturn(true);
-
-        ApiUpdateIncomeEvidenceResponse expectedResponse = new ApiUpdateIncomeEvidenceResponse()
-            .withApplicantEvidenceItems(new ApiIncomeEvidenceItems(applicantDetails, Collections.emptyList()))
-            .withPartnerEvidenceItems(new ApiIncomeEvidenceItems(partnerDetails, partnerEvidenceItems))
-            .withDueDate(evidenceDueDate)
-            .withAllEvidenceReceivedDate(evidenceReceivedDate);
-
-        ApiUpdateIncomeEvidenceResponse actualResponse = evidenceService.updateEvidence(updateEvidenceDTO);
-
-        Assertions.assertNotNull(updateEvidenceDTO.getEvidenceReceivedDate());
-        Assertions.assertEquals(expectedResponse, actualResponse);
-    }
-
-    private ApiApplicantDetails buildApplicantDetails(int applicantId, EmploymentStatus employmentStatus) {
-        ApiApplicantDetails applicantDetails = new ApiApplicantDetails();
-        applicantDetails.setId(applicantId);
-        applicantDetails.setEmploymentStatus(employmentStatus);
-
-        return applicantDetails;
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1402)

Implemented the create default income evidence logic in the income evidence service. The service is built to be stateless and returns the list of evidences along with the mandatory flag. The list of default income evidences are returned associated to an applicant or partner.

Alos, as part of this PR moved the updateIncome evidence logic from the EvidenceService into the IncomeEvidenceService.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.