### PR TITLE
Fix security vulnerability in spring-security-crypto

### DIFF
--- a/crime-evidence/build.gradle
+++ b/crime-evidence/build.gradle
@@ -21,7 +21,9 @@ def versions = [
         wmStubRunnerVersion   : "4.1.2",
         springDocWebMVCVersion: "2.5.0",
         postgresqlVersion     : "42.7.2",
-        tomcatEmbedCoreVersion : "10.1.34"
+        tomcatEmbedCoreVersion : "10.1.34",
+        oauth2ResourceServer   : "3.4.1",
+        securityCrypto         : "6.4.4"
 ]
 
 java {
@@ -48,8 +50,9 @@ dependencies {
     implementation "org.apache.tomcat.embed:tomcat-embed-core:$versions.tomcatEmbedCoreVersion"
 
     implementation "org.springframework.boot:spring-boot-starter-validation"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:$versions.oauth2ResourceServer"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation "org.springframework.security:spring-security-crypto:$versions.securityCrypto"
 
     implementation "org.postgresql:postgresql:$versions.postgresqlVersion"
     implementation "org.liquibase:liquibase-core"


### PR DESCRIPTION
This PR fixes the [recently published security vulnerability] (https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) in `spring-security-crypto` by forcibly bumping the dependency up to version `6.4.4`.

Spring Boot version `3.4.4` does patch `spring-security-crypto` to this same version, but in order to upgrade Spring Boot, Crime Commons modules also need to be upgraded at the same time, which has more potential to cause problems elsewhere. In that context and to ensure that the Orchestration Service can be as quickly fixed to allow deployments once again, this temporary fix is made in this PR until such time as Spring Boot is upgraded to `3.4.4`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1788)