### PR TITLE
LASB-4087 - Disable prod ingress and add ModSecurity to non-prod

### DIFF
--- a/helm_deploy/laa-crime-evidence/values-dev.yaml
+++ b/helm_deploy/laa-crime-evidence/values-dev.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crime-evidence-laa-crime-evidence-dev-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-evidence-dev"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-evidence-dev.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-evidence/values-prod.yaml
+++ b/helm_deploy/laa-crime-evidence/values-prod.yaml
@@ -40,18 +40,7 @@ service:
   targetPort: 8189
 
 ingress:
-  enabled: true
-  annotations:
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
-    external-dns.alpha.kubernetes.io/set-identifier: "laa-crime-evidence-laa-crime-evidence-prod-green"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
-  externalAnnotations: {}
-  hosts:
-    - host: laa-crime-evidence-prod.apps.live.cloud-platform.service.justice.gov.uk
-      paths: ["/open-api/"]
-  tls: []
-  className: default
+  enabled: false
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-evidence/values-test.yaml
+++ b/helm_deploy/laa-crime-evidence/values-test.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crime-evidence-laa-crime-evidence-test-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-evidence-test"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-evidence-test.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-evidence/values-uat.yaml
+++ b/helm_deploy/laa-crime-evidence/values-uat.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-crime-evidence-laa-crime-evidence-uat-green"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-evidence-uat"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-evidence-uat.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4087)

Disabled the ingress in prod and added ModSecurity to non-prod.

Please note, with the ModSecurity I have set it to DetectionOnly - This means requests won't be blocked, but will still be logged. This way we can monitor for a while and ensure it's not causing any false-positives before we start blocking requests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.